### PR TITLE
ENH: Fix call signature to save/load clip-planes.

### DIFF
--- a/EasyClip/EasyClip.py
+++ b/EasyClip/EasyClip.py
@@ -215,7 +215,8 @@ class EasyClipWidget(ScriptedLoadableModuleWidget):
         self.logic.saveFunction()
 
     def readPlane(self):
-        self.logic.readPlaneFunction(self.red_plane_box, self.yellow_plane_box, self.green_plane_box)
+        # Load plane matrix/function
+        self.logic.readPlaneFunction()
 
     def UndoButtonClicked(self):
         print "undo:"
@@ -518,22 +519,22 @@ class EasyClipLogic(ScriptedLoadableModuleLogic):
 
 
     def saveFunction(self):
-        filename = qt.QFileDialog.getSaveFileName(self, 'Save file')
+        filename = qt.QFileDialog.getSaveFileName(self.interface.parent, "Save file")
         tempDictionary = {}
         for key in self.ColorNodeCorrespondence:
             slice = slicer.util.getNode(self.ColorNodeCorrespondence[key])
             tempDictionary[key] = self.getMatrix(slice).tolist()
         if filename is None:
-            filename = qt.QFileDialog.getSaveFileName(self, 'Save file')
+            filename = qt.QFileDialog.getSaveFileName(self.interface.parent, "Save file")
         if filename != "":
             fileObj = open(filename, "wb")
             pickle.dump(tempDictionary, fileObj)
             fileObj.close()
 
-    def readPlaneFunction(self, red_plane_box, yellow_plane_box, green_plane_box):
-        filename = qt.QFileDialog.getOpenFileName(self, 'Open file')
+    def readPlaneFunction(self):
+        filename = qt.QFileDialog.getOpenFileName(self.interface.parent, "Open file")
         if filename is None:
-            filename = qt.QFileDialog.getOpenFileName(self, 'Open file')
+            filename = qt.QFileDialog.getOpenFileName(self.interface.parent, "Open file")
         if filename != "":
             fileObj = open(filename, "rb")
             tempDictionary = pickle.load(fileObj)
@@ -544,6 +545,7 @@ class EasyClipLogic(ScriptedLoadableModuleLogic):
                 for col in range(0, len(matList)):
                     for row in range(0, len(matList[col])):
                         matNode.SetElement(col, row, matList[col][row])
+                node.UpdateMatrices()
             fileObj.close()
 
     def encodeJSON(self, input):

--- a/EasyClip/EasyClip.py
+++ b/EasyClip/EasyClip.py
@@ -518,22 +518,22 @@ class EasyClipLogic(ScriptedLoadableModuleLogic):
 
 
     def saveFunction(self):
-        filename = qt.QFileDialog.getSaveFileName(parent=self,caption='Save file')
+        filename = qt.QFileDialog.getSaveFileName(self, 'Save file')
         tempDictionary = {}
         for key in self.ColorNodeCorrespondence:
             slice = slicer.util.getNode(self.ColorNodeCorrespondence[key])
             tempDictionary[key] = self.getMatrix(slice).tolist()
         if filename is None:
-            filename = qt.QFileDialog.getSaveFileName(parent=self, caption='Save file')
+            filename = qt.QFileDialog.getSaveFileName(self, 'Save file')
         if filename != "":
             fileObj = open(filename, "wb")
             pickle.dump(tempDictionary, fileObj)
             fileObj.close()
 
     def readPlaneFunction(self, red_plane_box, yellow_plane_box, green_plane_box):
-        filename = qt.QFileDialog.getOpenFileName(parent=self,caption='Open file')
+        filename = qt.QFileDialog.getOpenFileName(self, 'Open file')
         if filename is None:
-            filename = qt.QFileDialog.getOpenFileName(parent=self, caption='Open file')
+            filename = qt.QFileDialog.getOpenFileName(self, 'Open file')
         if filename != "":
             fileObj = open(filename, "rb")
             tempDictionary = pickle.load(fileObj)


### PR DESCRIPTION
Error code:
```bash
Traceback (most recent call last):
  File "/path/Software/Slicer/Extensions/EasyClip-Extension/build/lib/Slicer-4.9/qt-scripted-modules/EasyClip.py", line 215, in savePlane
    self.logic.saveFunction()
  File "/path/Software/Slicer/Extensions/EasyClip-Extension/build/lib/Slicer-4.9/qt-scripted-modules/EasyClip.py", line 521, in saveFunction
    filename = qt.QFileDialog.getSaveFileName(parent=self,caption='Save file')
```